### PR TITLE
Add Ubuntu 22.04 support

### DIFF
--- a/data/Ubuntu/22.04.yaml
+++ b/data/Ubuntu/22.04.yaml
@@ -1,0 +1,54 @@
+---
+# The commented text below is the /etc/nsswitch.conf from a freshly-built Ubuntu 22.04 Server.
+# # /etc/nsswitch.conf
+# #
+# # Example configuration of GNU Name Service Switch functionality.
+# # If you have the `glibc-doc-reference' and `info' packages installed, try:
+# # `info libc "Name Service Switch"' for information about this file.
+#
+# passwd:         files systemd
+# group:          files systemd
+# shadow:         files
+# gshadow:        files
+#
+# hosts:          files dns
+# networks:       files
+#
+# protocols:      db files
+# services:       db files
+# ethers:         db files
+# rpc:            db files
+#
+# netgroup:       nis
+#
+# The following YAML attempts to recreate the above file.
+
+nsswitch::passwd:
+  - files
+  - systemd
+nsswitch::group:
+  - files
+  - systemd
+nsswitch::shadow:
+  - files
+nsswitch::gshadow:
+  - files
+nsswitch::hosts:
+  - files
+  - dns
+nsswitch::networks:
+  - files
+nsswitch::protocols:
+  - db
+  - files
+nsswitch::rpc:
+  - db
+  - files
+nsswitch::services:
+  - db
+  - files
+nsswitch::ethers:
+  - db
+  - files
+nsswitch::netgroup:
+  - nis

--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that there is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for Ubuntu 22.04 LTS.

- Add Ubuntu 22.04 to the supported OSes in metadata.json.
- Add a YAML file to recreate the nsswitch.conf found in a vanilla Ubuntu Server 22.04 LTS.

#### This Pull Request (PR) fixes the following issues
n/a

#### The nsswitch.conf file in the Beaker container
```
$ docker exec -it -u root beaker-ubuntu2204-64-1-5843dbdf9be3 bash
root@ubuntu2204-64-1:/# cat /etc/nsswitch.conf 
# This file is controlled by Puppet

passwd:     files systemd
shadow:     files
gshadow:    files
group:      files systemd
hosts:      files dns
ethers:     db files
networks:   files
protocols:  db files
rpc:        db files
services:   db files
netgroup:   nis
root@ubuntu2204-64-1:/# exit
```
#### The nsswitch.conf file from the freshly-built Ubuntu 22.04 VM
```
# /etc/nsswitch.conf
#
# Example configuration of GNU Name Service Switch functionality.
# If you have the `glibc-doc-reference' and `info' packages installed, try:
# `info libc "Name Service Switch"' for information about this file.

passwd:         files systemd
group:          files systemd
shadow:         files
gshadow:        files

hosts:          files dns
networks:       files

protocols:      db files
services:       db files
ethers:         db files
rpc:            db files

netgroup:       nis
```