### PR TITLE
init: fix indentation formatting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,8 @@ class nsswitch (
     owner   => $file_owner,
     group   => $file_group,
     mode    => $file_perms,
-    content => epp('nsswitch/nsswitch.conf.epp', {
+    content => epp("${module_name}/nsswitch.conf.epp",
+      {
         'aliases'    => $aliases,
         'automount'  => $automount,
         'bootparams' => $bootparams,
@@ -137,6 +138,7 @@ class nsswitch (
         'gshadow'    => $gshadow,
         'sudoers'    => $sudoers,
         'subid'      => $subid,
-    }),
+      },
+    ),
   }
 }


### PR DESCRIPTION
It looks wrong and is harder to read when there is code indented by more
than two spaces.
